### PR TITLE
Compatibility with testthat 1.1.0

### DIFF
--- a/tests/testthat/test-ichimoku.R
+++ b/tests/testthat/test-ichimoku.R
@@ -63,6 +63,6 @@ test_that("is.ichimoku ok", {
 })
 
 test_that("print.ichimoku print method ok", {
-  expect_s3_class(print(cloud), "ichimoku")
-  expect_s3_class(print(cloud, plot = FALSE), "ichimoku")
+  expect_output(expect_s3_class(print(cloud), "ichimoku"))
+  expect_output(expect_s3_class(print(cloud, plot = FALSE), "ichimoku"))
 })

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -11,9 +11,9 @@ test_that("extraplot ok", {
   expect_s3_class(extraplot(strat, theme = "original", type = "r", custom = "nonexist"), "gtable")
   expect_s3_class(extraplot(strat, type = "line", custom = "posn"), "gtable")
   expect_s3_class(extraplot(cloud, type = "bar", custom = "vol"), "gtable")
-  expect_s3_class(expect_warning(extraplot(cloud), "'type' not specified"), "ggplot")
-  expect_s3_class(expect_warning(extraplot(cloud, type = "line"), "'custom' not specified"), "ggplot")
-  expect_s3_class(expect_warning(extraplot(cloud, type = "bar", custom = "vix"), "does not match"), "ggplot")
+  expect_warning(expect_s3_class(extraplot(cloud), "ggplot"), "'type' not specified")
+  expect_warning(expect_s3_class(extraplot(cloud, type = "line"), "ggplot"), "'custom' not specified")
+  expect_warning(expect_s3_class(extraplot(cloud, type = "bar", custom = "vix"), "ggplot"), "does not match")
 })
 
 test_that("ichimoku plot method ok", {


### PR DESCRIPTION
Unfortunately the upcoming testthat 1.1.0 makes some minor changes to how `expect_warning()` works that broke your tests. We'll hopefully be submitting testthat to CRAN on Friday, so you may want to re-release in the near future to avoid test failures on CRAN.